### PR TITLE
Option to load DICOM in the main thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ endif()
 option(ALIZA_MEDIASTORAGE_MODE "Build for media storage" OFF)
 mark_as_advanced(ALIZA_MEDIASTORAGE_MODE)
 
+option(ALIZA_LOAD_DCM_THREAD "Load DICOM in separate thread" ON)
+
 # Temporary
 set(TMP_USE_53_SPATIAL_ENUMS TRUE)
 
@@ -197,6 +199,10 @@ if(NOT WIN32)
   endif()
 endif()
 message(STATUS "CXX flags: " ${CMAKE_CXX_FLAGS})
+
+if(ALIZA_LOAD_DCM_THREAD)
+  add_definitions(-DALIZA_LOAD_DCM_THREAD)
+endif()
 
 if(ALIZA_QT_VERSION STREQUAL "4")
   set(USE_QT_V_4 TRUE)
@@ -795,7 +801,6 @@ set(ALIZAMS_SRCS ${ALIZAMS_SRCS}
   ${CMAKE_CURRENT_SOURCE_DIR}/dicom/splituihgridfilter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/dicom/spectroscopyutils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/dicom/srutils.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/dicom/loaddicom.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/CG/camera.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/CG/glwidget.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/CG/testgl.cpp
@@ -838,6 +843,12 @@ set(ALIZAMS_SRCS ${ALIZAMS_SRCS}
   ${CMAKE_CURRENT_SOURCE_DIR}/browser/anonymazerwidget2.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/GUI/aliza.cpp)
 
+if(ALIZA_LOAD_DCM_THREAD)
+  set(ALIZAMS_SRCS ${ALIZAMS_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/dicom/loaddicom_t.cpp)
+else()
+  set(ALIZAMS_SRCS ${ALIZAMS_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/dicom/loaddicom.cpp)
+endif()
+
 if(NOT ALIZA_MEDIASTORAGE_MODE)
   set(ALIZAMS_SRCS ${ALIZAMS_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/browser/ctkdialog.cpp)
 endif()
@@ -858,7 +869,6 @@ set(ALIZAMS_MOC_HRDS
   ${CMAKE_CURRENT_SOURCE_DIR}/browser/browserwidget2.h
   ${CMAKE_CURRENT_SOURCE_DIR}/browser/helpwidget.h
   ${CMAKE_CURRENT_SOURCE_DIR}/browser/anonymazerwidget2.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/dicom/loaddicom.h
   ${CMAKE_CURRENT_SOURCE_DIR}/GUI/findrefdialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/GUI/infodialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/GUI/imageinfodialog.h
@@ -885,6 +895,10 @@ set(ALIZAMS_MOC_HRDS
   ${CMAKE_CURRENT_SOURCE_DIR}/GUI/aboutwidget.h
   ${CMAKE_CURRENT_SOURCE_DIR}/GUI/srwidget.h
   ${CMAKE_CURRENT_SOURCE_DIR}/GUI/aliza.h)
+
+if(ALIZA_LOAD_DCM_THREAD)
+  set(ALIZAMS_MOC_HRDS ${ALIZAMS_MOC_HRDS} ${CMAKE_CURRENT_SOURCE_DIR}/dicom/loaddicom_t.h)
+endif()
 
 if(APPLE)
   if(USE_QT_V_6)

--- a/GUI/mainwindow.cpp
+++ b/GUI/mainwindow.cpp
@@ -17,8 +17,6 @@
 #include "commonutils.h"
 #include "infodialog.h"
 
-#define DISABLE_LEFT_TOOLBAR__
-
 namespace
 {
 
@@ -594,12 +592,18 @@ void MainWindow::open_args(const QStringList & l)
 		QList<QPushButton *> lb = pb->findChildren<QPushButton*>();
 		for (int x = 0; x < lb.size(); ++x) // one button
 		{
+#ifdef ALIZA_LOAD_DCM_THREAD
 			lb[x]->setStyleSheet("QPushButton { color: #8B0000; }");
+#else
+			lb[x]->hide();
+#endif
 		}
 	}
 	pb->setModal(true);
 	pb->setWindowFlags(pb->windowFlags() ^ Qt::WindowContextHelpButtonHint);
+#ifdef ALIZA_LOAD_DCM_THREAD
 	connect(pb,SIGNAL(canceled()), this, SLOT(exit_null()));
+#endif
 	pb->setMinimumWidth(256);
 	pb->setRange(0, 0);
 	pb->setMinimumDuration(0);
@@ -646,7 +650,9 @@ void MainWindow::open_args(const QStringList & l)
 			}
 		}
 	}
+#ifdef ALIZA_LOAD_DCM_THREAD
 	disconnect(pb,SIGNAL(canceled()), this, SLOT(exit_null()));
+#endif
 	pb->close();
 	delete pb;
 	if (!message.isEmpty())
@@ -1430,12 +1436,18 @@ void MainWindow::dropEvent(QDropEvent * e)
 				QList<QPushButton *> lb = pb->findChildren<QPushButton*>();
 				for (int x = 0; x < lb.size(); ++x) // one button
 				{
+#ifdef ALIZA_LOAD_DCM_THREAD
 					lb[x]->setStyleSheet("QPushButton { color: #8B0000; }");
+#else
+					lb[x]->hide();
+#endif
 				}
 			}
 			pb->setModal(true);
 			pb->setWindowFlags(pb->windowFlags() ^ Qt::WindowContextHelpButtonHint);
+#ifdef ALIZA_LOAD_DCM_THREAD
 			connect(pb, SIGNAL(canceled()), this, SLOT(exit_null()));
+#endif
 			pb->setMinimumWidth(256);
 			pb->setRange(0, 0);
 			pb->setMinimumDuration(0);
@@ -1460,7 +1472,9 @@ void MainWindow::dropEvent(QDropEvent * e)
 					}
 				}
 			}
+#ifdef ALIZA_LOAD_DCM_THREAD
 			disconnect(pb,SIGNAL(canceled()),this,SLOT(exit_null()));
+#endif
 			pb->close();
 			delete pb;
 		}
@@ -1508,10 +1522,16 @@ void MainWindow::load_any()
 		QList<QPushButton *> lb = pb->findChildren<QPushButton*>();
 		for (int x = 0; x < lb.size(); ++x) // one button
 		{
+#ifdef ALIZA_LOAD_DCM_THREAD
 			lb[x]->setStyleSheet("QPushButton { color: #8B0000; }");
+#else
+			lb[x]->hide();
+#endif
 		}
 	}
+#ifdef ALIZA_LOAD_DCM_THREAD
 	connect(pb, SIGNAL(canceled()), this, SLOT(exit_null()));
+#endif
 	pb->setModal(true);
 	pb->setWindowFlags(pb->windowFlags() ^ Qt::WindowContextHelpButtonHint);
 	pb->setMinimumWidth(256);
@@ -1539,7 +1559,9 @@ void MainWindow::load_any()
 		}
 	}
 	l.clear();
+#ifdef ALIZA_LOAD_DCM_THREAD
 	disconnect(pb,SIGNAL(canceled()),this,SLOT(exit_null()));
+#endif
 	pb->close();
 	delete pb;
 	if (is_dicomdir)
@@ -1692,10 +1714,16 @@ void MainWindow::load_dicom_series2()
 		QList<QPushButton *> lb = pb->findChildren<QPushButton*>();
 		for (int x = 0; x < lb.size(); ++x) // one button
 		{
+#ifdef ALIZA_LOAD_DCM_THREAD
 			lb[x]->setStyleSheet("QPushButton { color: #8B0000; }");
+#else
+			lb[x]->hide();
+#endif
 		}
 	}
+#ifdef ALIZA_LOAD_DCM_THREAD
 	connect(pb, SIGNAL(canceled()), this, SLOT(exit_null()));
+#endif
 	pb->setModal(true);
 	pb->setWindowFlags(pb->windowFlags() ^ Qt::WindowContextHelpButtonHint);
 	pb->setMinimumWidth(256);
@@ -1707,7 +1735,9 @@ void MainWindow::load_dicom_series2()
 #endif
 	qApp->processEvents();
 	const QString message = aliza->load_dicom_series(pb);
+#ifdef ALIZA_LOAD_DCM_THREAD
 	disconnect(pb, SIGNAL(canceled()), this, SLOT(exit_null()));
+#endif
 	pb->close();
 	delete pb;
 	if (!message.isEmpty())

--- a/common/commonutils.cpp
+++ b/common/commonutils.cpp
@@ -48,6 +48,7 @@
 #include <chrono>
 #include <functional>
 #include <cfloat>
+#include <atomic>
 #include "dicomutils.h"
 #include "colorspace/colorspace.h"
 #ifdef USE_GET_TOTAL_MEM
@@ -58,6 +59,11 @@
 #endif
 #endif
 
+#ifdef ALIZA_LINUX_DEBUG_MEM
+#include <unistd.h>
+#include <ios>
+#include <fstream>
+#endif
 
 namespace
 {
@@ -1961,14 +1967,14 @@ template<typename T> double get_value(
 
 int CommonUtils::get_next_id()
 {
-	static int id___ = 0;
+	static std::atomic<int> id___{};
 	++id___;
 	return id___;
 }
 
 int CommonUtils::get_next_group_id()
 {
-	static int group_id___ = 0;
+	static std::atomic<int> group_id___{};
 	++group_id___;
 	return group_id___;
 }
@@ -3624,7 +3630,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 				{
 					p__ = &data[0][0];
 				}
-				bool bad_direction = true;
+				bool bad_direction{true};
 				error = process_dicom_monochrome_image1<ImageTypeUS>(
 					ok,
 					ivariant,
@@ -3704,7 +3710,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 				{
 					p__ = &data[0][0];
 				}
-				bool bad_direction = true;
+				bool bad_direction{true};
 				error = process_dicom_monochrome_image1<ImageTypeSI>(
 					ok,
 					ivariant,
@@ -3784,7 +3790,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 				{
 					p__ = &data[0][0];
 				}
-				bool bad_direction = true;
+				bool bad_direction{true};
 				error = process_dicom_monochrome_image1<ImageTypeUI>(
 					ok,
 					ivariant,
@@ -3864,7 +3870,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 				{
 					p__ = &data[0][0];
 				}
-				bool bad_direction = true;
+				bool bad_direction{true};
 				error = process_dicom_monochrome_image1<ImageTypeSLL>(
 					ok,
 					ivariant,
@@ -3944,7 +3950,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 				{
 					p__ = &data[0][0];
 				}
-				bool bad_direction = true;
+				bool bad_direction{true};
 				error = process_dicom_monochrome_image1<ImageTypeULL>(
 					ok,
 					ivariant,
@@ -4027,7 +4033,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 					p__ = &data[0][0];
 				}
 				ivariant->di->maxwindow = true;
-				bool bad_direction = true;
+				bool bad_direction{true};
 				error = process_dicom_monochrome_image1<ImageTypeUC>(
 					ok,
 					ivariant,
@@ -4107,7 +4113,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 				{
 					p__ = &data[0][0];
 				}
-				bool bad_direction = true;
+				bool bad_direction{true};
 				error = process_dicom_monochrome_image1<ImageTypeF>(
 					ok,
 					ivariant,
@@ -4187,7 +4193,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 				{
 					p__ = &data[0][0];
 				}
-				bool bad_direction = true;
+				bool bad_direction{true};
 				error = process_dicom_monochrome_image1<ImageTypeD>(
 					ok,
 					ivariant,
@@ -4287,7 +4293,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 			{
 				p__ = &data[0][0];
 			}
-			bool bad_direction = true;
+			bool bad_direction{true};
 			error = process_dicom_rgb_image1<RGBImageTypeUC>(
 				ok,
 				ivariant,
@@ -4375,7 +4381,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 			{
 				p__ = &data[0][0];
 			}
-			bool bad_direction = true;
+			bool bad_direction{true};
 			error = process_dicom_rgb_image1<RGBImageTypeUS>(
 				ok,
 				ivariant,
@@ -4462,7 +4468,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 			{
 				p__ = &data[0][0];
 			}
-			bool bad_direction = true;
+			bool bad_direction{true};
 			error = process_dicom_rgb_image1<RGBImageTypeSS>(
 				ok,
 				ivariant,
@@ -4547,7 +4553,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 			{
 				p__ = &data[0][0];
 			}
-			bool bad_direction = true;
+			bool bad_direction{true};
 			error = process_dicom_rgb_image1<RGBImageTypeF>(
 				ok,
 				ivariant,
@@ -4654,7 +4660,7 @@ QString CommonUtils::gen_itk_image(bool * ok,
 			{
 				p__ = &data[0][0];
 			}
-			bool bad_direction = true;
+			bool bad_direction{true};
 			error = process_dicom_rgba_image1<RGBAImageTypeUC>(
 				ok,
 				ivariant,
@@ -5105,6 +5111,68 @@ void CommonUtils::random_RGB(float * R, float * G, float * B)
 	*G = static_cast<float>(G_);
 	*B = static_cast<float>(B_);
 }
+
+// clang-format off
+int CommonUtils::get_reference_count(const ImageVariant * v)
+{
+	if (!v)
+	{
+		std::cout << "Image is null (ref. count not possible)" << std::endl;
+		return -1;
+	}
+	int x{};
+	bool b{};
+	if (v->pSS.IsNotNull())      {                       x = v->pSS->GetReferenceCount();     }
+	if (v->pUS.IsNotNull())      {if (x > 0) {b = true;} x = v->pUS->GetReferenceCount();     }
+	if (v->pSI.IsNotNull())      {if (x > 0) {b = true;} x = v->pSI->GetReferenceCount();     }
+	if (v->pUI.IsNotNull())      {if (x > 0) {b = true;} x = v->pUI->GetReferenceCount();     }
+	if (v->pUC.IsNotNull())      {if (x > 0) {b = true;} x = v->pUC->GetReferenceCount();     }
+	if (v->pF.IsNotNull())       {if (x > 0) {b = true;} x = v->pF->GetReferenceCount();      }
+	if (v->pD.IsNotNull())       {if (x > 0) {b = true;} x = v->pD->GetReferenceCount();      }
+	if (v->pSLL.IsNotNull())     {if (x > 0) {b = true;} x = v->pSLL->GetReferenceCount();    }
+	if (v->pULL.IsNotNull())     {if (x > 0) {b = true;} x = v->pULL->GetReferenceCount();    }
+	if (v->pSS_rgb.IsNotNull())  {if (x > 0) {b = true;} x = v->pSS_rgb->GetReferenceCount(); }
+	if (v->pUS_rgb.IsNotNull())  {if (x > 0) {b = true;} x = v->pUS_rgb->GetReferenceCount(); }
+	if (v->pSI_rgb.IsNotNull())  {if (x > 0) {b = true;} x = v->pSI_rgb->GetReferenceCount(); }
+	if (v->pUI_rgb.IsNotNull())  {if (x > 0) {b = true;} x = v->pUI_rgb->GetReferenceCount(); }
+	if (v->pUC_rgb.IsNotNull())  {if (x > 0) {b = true;} x = v->pUC_rgb->GetReferenceCount(); }
+	if (v->pF_rgb.IsNotNull())   {if (x > 0) {b = true;} x = v->pF_rgb->GetReferenceCount();  }
+	if (v->pD_rgb.IsNotNull())   {if (x > 0) {b = true;} x = v->pD_rgb->GetReferenceCount();  }
+	if (v->pSS_rgba.IsNotNull()) {if (x > 0) {b = true;} x = v->pSS_rgba->GetReferenceCount();}
+	if (v->pUS_rgba.IsNotNull()) {if (x > 0) {b = true;} x = v->pUS_rgba->GetReferenceCount();}
+	if (v->pSI_rgba.IsNotNull()) {if (x > 0) {b = true;} x = v->pSI_rgba->GetReferenceCount();}
+	if (v->pUI_rgba.IsNotNull()) {if (x > 0) {b = true;} x = v->pUI_rgba->GetReferenceCount();}
+	if (v->pUC_rgba.IsNotNull()) {if (x > 0) {b = true;} x = v->pUC_rgba->GetReferenceCount();}
+	if (v->pF_rgba.IsNotNull())  {if (x > 0) {b = true;} x = v->pF_rgba->GetReferenceCount(); }
+	if (v->pD_rgba.IsNotNull())  {if (x > 0) {b = true;} x = v->pD_rgba->GetReferenceCount(); }
+	std::cout << "Ref. count = " << x << (b ? ", multiple images" : " ") << std::endl;
+	return x;
+}
+// clang-format on
+
+#ifdef ALIZA_LINUX_DEBUG_MEM
+void CommonUtils::linux_print_memusage(const std::string & s)
+{
+   std::ifstream stat_stream("/proc/self/stat", std::ios_base::in);
+   // Vars for leading unused entries
+   std::string pid, comm, state, ppid, pgrp, session, tty_nr;
+   std::string tpgid, flags, minflt, cminflt, majflt, cmajflt;
+   std::string utime, stime, cutime, cstime, priority, nice;
+   std::string O, itrealvalue, starttime;
+   // The two used fields
+   unsigned long long vsize;
+   long long rss;
+   stat_stream >> pid >> comm >> state >> ppid >> pgrp >> session >> tty_nr
+               >> tpgid >> flags >> minflt >> cminflt >> majflt >> cmajflt
+               >> utime >> stime >> cutime >> cstime >> priority >> nice
+               >> O >> itrealvalue >> starttime >> vsize >> rss; // don't care about the rest
+   stat_stream.close();
+   const unsigned long long page_size_kb = sysconf(_SC_PAGE_SIZE);
+   const long double vm_usage = vsize / 1073741824.0L;
+   const long double resident_set = (rss * page_size_kb) / 1073741824.0L;
+   std::cout << s << ": VM = " << vm_usage << " GB, RSS = " << resident_set << " GB " << std::endl;
+}
+#endif
 
 #ifdef USE_GET_TOTAL_MEM
 #undef USE_GET_TOTAL_MEM

--- a/common/commonutils.h
+++ b/common/commonutils.h
@@ -1,6 +1,8 @@
 #ifndef A_COMMONUTILS_H
 #define A_COMMONUTILS_H
 
+//#define ALIZA_LINUX_DEBUG_MEM
+
 #include <QStringList>
 #include <QString>
 #include <QByteArray>
@@ -116,6 +118,10 @@ public:
 		QList<double> &);
 	static double calculate_max_delta(const ImageVariant*);
 	static void random_RGB(float*, float*, float*);
+	static int get_reference_count(const ImageVariant*);
+#ifdef ALIZA_LINUX_DEBUG_MEM
+	static void linux_print_memusage(const std::string&);
+#endif
 };
 
 #endif

--- a/dicom/loaddicom_t.cpp
+++ b/dicom/loaddicom_t.cpp
@@ -1,0 +1,35 @@
+#include "structures.h"
+#include "loaddicom_t.h"
+#include "dicomutils.h"
+#include <iostream>
+
+void LoadDicom_T::run()
+{
+	try
+	{
+		message = DicomUtils::read_dicom(
+			ivariants,
+			pdf_files,
+			stl_files,
+			video_files,
+			spectroscopy_files,
+			sr_files,
+			root,
+			filenames,
+			ok3d,
+			settingswidget,
+			load_type,
+			enh_type);
+	}
+	catch (const mdcm::ParseException & pe)
+	{
+		std::cout << "mdcm::ParseException in Aliza::load_dicom_series:\n"
+			<< pe.GetLastElement().GetTag() << std::endl;
+	}
+	catch (const std::exception & ex)
+	{
+		std::cout << "Exception in Aliza::load_dicom_series\n"
+			<< ex.what() << std::endl;
+	}
+}
+

--- a/dicom/loaddicom_t.h
+++ b/dicom/loaddicom_t.h
@@ -1,6 +1,7 @@
-#ifndef A_LOADDICOM_H
-#define A_LOADDICOM_H
+#ifndef A_LOADDICOM_T_H
+#define A_LOADDICOM_T_H
 
+#include <QThread>
 #include <QWidget>
 #include <QString>
 #include <QStringList>
@@ -8,11 +9,12 @@
 
 class ImageVariant;
 
-class LoadDicom
+class LoadDicom_T : public QThread
 {
+Q_OBJECT
 
 public:
-	LoadDicom(
+	LoadDicom_T(
 		const QString root_,
 		const QStringList & filenames_,
 		const bool ok3d_,
@@ -26,7 +28,7 @@ public:
 		settingswidget(settingswidget_),
 		load_type(load_type_),
 		enh_type(enh_type_) {}
-	~LoadDicom() {}
+	virtual ~LoadDicom_T() {}
 	void run();
 	QString message;
 	std::vector<ImageVariant*> ivariants;

--- a/dicom/prconfigutils.cpp
+++ b/dicom/prconfigutils.cpp
@@ -37,6 +37,9 @@
 #include <itkImageDuplicator.h>
 #include <QMap>
 #include <QMultiMap>
+#ifndef ALIZA_LOAD_DCM_THREAD
+#include <QApplication>
+#endif
 #include <vector>
 #include <iostream>
 #include <mdcmDataElement.h>
@@ -3403,6 +3406,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 				return nullptr;
 			}
 		}
+#ifndef ALIZA_LOAD_DCM_THREAD
+		QApplication::processEvents();
+#endif
 	}
 	//
 	// VOI LUT
@@ -3465,6 +3471,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 			}
 			voi = true;
 		}
+#ifndef ALIZA_LOAD_DCM_THREAD
+		QApplication::processEvents();
+#endif
 	}
 	//
 	// Presentation LUT
@@ -3545,6 +3554,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 				}
 			}
 		}
+#ifndef ALIZA_LOAD_DCM_THREAD
+		QApplication::processEvents();
+#endif
 	}
 	//
 	//
@@ -3720,6 +3732,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 				area_images,
 				ivariant->image_instance_uids);
 		}
+#ifndef ALIZA_LOAD_DCM_THREAD
+		QApplication::processEvents();
+#endif
 	}
 	//
 	// Spatial transform
@@ -3757,6 +3772,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 				break;
 			}
 		}
+#ifndef ALIZA_LOAD_DCM_THREAD
+		QApplication::processEvents();
+#endif
 	}
 	CommonUtils::get_dimensions_(v);
 	//
@@ -3918,6 +3936,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 			}
 #endif
 		}
+#ifndef ALIZA_LOAD_DCM_THREAD
+		QApplication::processEvents();
+#endif
 	}
 	//
 	// Graphic annotations
@@ -4006,6 +4027,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 			}
 #endif
 		}
+#ifndef ALIZA_LOAD_DCM_THREAD
+		QApplication::processEvents();
+#endif
 	}
 	//
 	// Display shutter
@@ -4061,6 +4085,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 			}
 		}
 #endif
+#ifndef ALIZA_LOAD_DCM_THREAD
+		QApplication::processEvents();
+#endif
 	}
 	//
 	//
@@ -4097,6 +4124,9 @@ ImageVariant * PrConfigUtils::make_pr_monochrome(
 			}
 		}
 	}
+#ifndef ALIZA_LOAD_DCM_THREAD
+	QApplication::processEvents();
+#endif
 	//
 	//
 	//

--- a/mdcm/Source/MediaStorageAndFileFormat/mdcmEncapsulatedRAWCodec.cxx
+++ b/mdcm/Source/MediaStorageAndFileFormat/mdcmEncapsulatedRAWCodec.cxx
@@ -128,7 +128,7 @@ EncapsulatedRAWCodec::Decode2(DataElement const & in, char * out_buffer, unsigne
   memcpy(
     out_buffer,
     tmp1,
-    ((len < len2) ? out_len : len2));
+    ((out_len < len2) ? out_len : len2));
 #endif
   return true;
 }


### PR DESCRIPTION
There are strange issues with memory usage on Linux (only on Linux), not yet sure is it a real problem or not, maybe there are no issues, just some special Linux stuff. But created the CMake option ALIZA_LOAD_DCM_THREAD to control this. Also added some diagnostic functions (disabled by default).